### PR TITLE
fix_genre

### DIFF
--- a/app/views/admin/products/new.html.erb
+++ b/app/views/admin/products/new.html.erb
@@ -22,7 +22,7 @@
 		<%= f.text_area :introduction %>
 	</div>
 
-	<%= f.collection_select :genre_id, Genre.all, :id, :name, include_blank: "選択して下さい" %>
+	<%= f.collection_select :genre_id, Genre.where(is_active: 1), :id, :name, include_blank: "選択して下さい" %>
 
     <div class="field ">
 		<%= f.label :price %><br>


### PR DESCRIPTION
商品新規作成ページのジャンル選択プルダウンにステータス無効のジャンルまで表示されるバグの修正を行いました。お時間ある時に確認してください。