### PR TITLE
fix_branch

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,10 +1,15 @@
 class ApplicationController < ActionController::Base
 
   before_action :configure_permitted_parameters, if: :devise_controller?
-  # prepend_before_filter :require_no_authentication, :only => [ :cancel] 
+  # prepend_before_filter :require_no_authentication, :only => [ :cancel]
 
   def after_sign_in_path_for(resource)
-    client_products_path(genre_sort: 0)
+    case resource
+      when Admin
+        admin_admins_top_path
+      when Client
+      client_products_path(genre_sort: 0)
+    end
   end
 
   def after_sign_out_path_for(resource)

--- a/app/controllers/client/orders_controller.rb
+++ b/app/controllers/client/orders_controller.rb
@@ -1,151 +1,156 @@
 class Client::OrdersController < ApplicationController
 
 
-    # private以下で @client = current_client のアクション
-    before_action :set_client
+  # private以下で @client = current_client のアクション
+  before_action :set_client
 
-    def index
-      @orders = @client.orders
+  def index
+    @orders = @client.orders
+  end
+
+  def show
+    @order = Order.find(params[:id])
+    if @order.client_id != current_client.id
+      redirect_back(fallback_location: root_path)
+      flash[:alert] = "アクセスに失敗しました"
     end
-
-    def show
-      @order = Order.find(params[:id])
-      if @order.client_id != current_client.id
-        redirect_back(fallback_location: root_path)
-        flash[:alert] = "アクセスに失敗しました"
-      end
-    end
+  end
 
 
-    def new
-      current_client_cart = current_client.cart_products
-      if current_client_cart.blank?
-        redirect_to client_cart_products_path(current_client)
-      else
-        @order = Order.new
-      end
-    end
-
-
-    def confirm
+  def new
+    current_client_cart = current_client.cart_products
+    if current_client_cart.blank?
+      redirect_to client_cart_products_path(current_client)
+    else
       @order = Order.new
-      @cart_products = current_client.cart_products
+    end
+  end
+
+
+  def confirm
+    @order = Order.new
+    @cart_products = current_client.cart_products
+    @order.payment_method = params[:order][:payment_method]
+
+    # 合計金額を求める
+    sum_all = 0
+    @cart_products.each do |cp|
+      sum_product = price_include_tax(cp.product.price).to_i * cp.count
+      sum_all += sum_product
+    end
+    @order.total_bill = sum_all + @order.postage
+
+    # どのラジオボタンを押したかを数字で渡す
+    @add = params[:order][:add].to_i
+    case @add
+      # 自分の住所
+    when 1
+      @order.postal_code   = @client.postal_code
+      @order.address       = @client.address
+      @order.name          = @client.last_name + @client.first_name
+     # 登録済住所
+    when 2
+    @sta = params[:order][:address].to_i
+      if @sta == 0
+        render "new"
+      elsif
+        @shipping_address = ShippingAddress.find(@sta)
+        @order.postal_code     = @shipping_address.postal_code
+        @order.address         = @shipping_address.address
+        @order.name            = @shipping_address.destination
+     end
+     
+     # 入力された新しい住所
+    when 3
+    if params[:order][:new_add][:postal_code].blank? || params[:order][:new_add][:address].blank? || params[:order][:new_add][:destination].blank?
+      render :new
+    else
+      @order.postal_code     = params[:order][:new_add][:postal_code]
+      @order.address         = params[:order][:new_add][:address]
+      @order.name            = params[:order][:new_add][:destination]
+    end
+   end
+  end
+
+
+  def create
+
+    if current_client.cart_products.exists?
+      @order = Order.new(order_params)
+      @order.client_id = current_client.id
       @order.payment_method = params[:order][:payment_method]
 
       # 合計金額を求める
       sum_all = 0
-      @cart_products.each do |cp|
+      cart_product = current_client.cart_products
+      cart_product.each do |cp|
         sum_product = price_include_tax(cp.product.price).to_i * cp.count
         sum_all += sum_product
       end
       @order.total_bill = sum_all + @order.postage
 
+
       # どのラジオボタンを押したかを数字で渡す
       @add = params[:order][:add].to_i
       case @add
         # 自分の住所
-      when 1
-        @order.postal_code   = @client.postal_code
-        @order.address       = @client.address
-        @order.name          = @client.first_name + @client.last_name
-       # 登録済住所
-      when 2
-       @sta = params[:order][:address].to_i
-       @shipping_address = ShippingAddress.find(@sta)
-       @order.postal_code     = @shipping_address.postal_code
-       @order.address         = @shipping_address.address
-       @order.name            = @shipping_address.destination
-       # 入力された新しい住所
-      when 3
-      if params[:order][:new_add][:postal_code].blank? || params[:order][:new_add][:address].blank? || params[:order][:new_add][:destination].blank?
-        render :new
-      else
-        @order.postal_code     = params[:order][:new_add][:postal_code]
-        @order.address         = params[:order][:new_add][:address]
-        @order.name            = params[:order][:new_add][:destination]
+        when 1
+          @order.postal_code = @client.postal_code
+          @order.address = @client.address
+          @order.name = @client.first_name + @client.last_name
+        # 登録済住所
+        when 2
+          @order.postal_code = params[:order][:postal_code]
+          @order.address = params[:order][:address]
+          @order.name = params[:order][:name]
+         # 新しいお届け先
+        when 3
+          @order.postal_code = params[:order][:postal_code]
+          @order.address = params[:order][:address]
+          @order.name = params[:order][:name]
       end
-     end
-    end
+      @order.save!
 
-
-    def create
-
-      if current_client.cart_products.exists?
-        @order = Order.new(order_params)
-        @order.client_id = current_client.id
-        @order.payment_method = params[:order][:payment_method]
-
-        # 合計金額を求める
-        sum_all = 0
-        cart_product = current_client.cart_products
-        cart_product.each do |cp|
-          sum_product = price_include_tax(cp.product.price).to_i * cp.count
-          sum_all += sum_product
-        end
-        @order.total_bill = sum_all + @order.postage
-
-
-        # どのラジオボタンを押したかを数字で渡す
-        @add = params[:order][:add].to_i
-        case @add
-          # 自分の住所
-          when 1
-            @order.postal_code = @client.postal_code
-            @order.address = @client.address
-            @order.name = @client.first_name + @client.last_name
-          # 登録済住所
-          when 2
-            @order.postal_code = params[:order][:postal_code]
-            @order.address = params[:order][:address]
-            @order.name = params[:order][:name]
-           # 新しいお届け先
-          when 3
-            @order.postal_code = params[:order][:postal_code]
-            @order.address = params[:order][:address]
-            @order.name = params[:order][:name]
-        end
-        @order.save!
-
-        # cart_productsの内容をorder_productsに新規登録
-        current_client.cart_products.each do |cp|
-          order_products              = @order.order_products.build
-          order_products.order_id     = @order.id
-          order_products.product_id   = cp.product_id
-          order_products.price        = cp.product.price
-          order_products.count        = cp.count
-          order_products.save
-          cp.destroy
-        end
-        render :thanks
-
-      else
-        redirect_to client_products_path(genre_sort: 0)
-        flash[:danger] = 'カートが空です。'
+      # cart_productsの内容をorder_productsに新規登録
+      current_client.cart_products.each do |cp|
+        order_products              = @order.order_products.build
+        order_products.order_id     = @order.id
+        order_products.product_id   = cp.product_id
+        order_products.price        = price_include_tax(cp.product.price)
+        order_products.count        = cp.count
+        order_products.save
+        cp.destroy
       end
+      render :thanks
 
+    else
+      redirect_to client_products_path(genre_sort: 0)
+      flash[:danger] = 'カートが空です。'
     end
 
-
-
-    def thanks
-    end
-
-
-    private
-
-
-    def set_client
-      @client = current_client
-    end
+  end
 
 
 
-    def order_params
-      # 注文の際の注文商品も保存するようにする
-      params.require(:order).permit(
-        :status, :postal_code, :address, :name, :postage, :total_bill, :payment_method,
-        order_products_attributes: [:order_id, :product_id, :price, :count, :making_status]
-      )
-    end
+  def thanks
+  end
+
+
+  private
+
+
+  def set_client
+    @client = current_client
+  end
+
+
+
+  def order_params
+    # 注文の際の注文商品も保存するようにする
+    params.require(:order).permit(
+      :status, :postal_code, :address, :name, :postage, :total_bill, :payment_method,
+      order_products_attributes: [:order_id, :product_id, :price, :count, :making_status]
+    )
+  end
 
 end

--- a/app/controllers/client/products_controller.rb
+++ b/app/controllers/client/products_controller.rb
@@ -1,21 +1,42 @@
 class Client::ProductsController < ApplicationController
 
+  before_action :active_genres, only: [:index]
+  before_action :active_products, only: [:show]
+
     def index
-      @genres = Genre.all
+      @genres = Genre.where(is_active: 1)
       if params[:genre_sort] == "0" || params[:genre_sort] == nil
-        @products = Product.all
+        @products = Product.where(is_active: 1)
+
       else
-        @products = Product.where(genre_id: params[:genre_sort].to_i)
+        @products = Product.where(genre_id: params[:genre_sort].to_i,is_active: 1)
         genre = Genre.find_by(id: params[:genre_sort].to_i)
         @genre_name = genre.name
       end
     end
 
     def show
-      @genres = Genre.all
+      @genres = Genre.where(is_active: 1)
       @product = Product.find(params[:id])
       @tax_price = @product.price
       @cart_product = CartProduct.new
     end
+
+    private
+
+    def active_genres
+      if params[:genre_sort] == "0" || params[:genre_sort] == nil
+      else
+        before_genre = Genre.find_by(id: params[:genre_sort])
+        redirect_to client_products_path if before_genre.is_active == 0
+      end
+    end
+    
+
+    def active_products
+      product = Product.find(params[:id])
+      redirect_to client_products_path if product.is_active == 2
+    end
+    
 
 end

--- a/app/views/admin/orders/index.html.erb
+++ b/app/views/admin/orders/index.html.erb
@@ -16,7 +16,13 @@
           <tr>
               <td><%= link_to order.created_at.strftime('%Y/%m/%d'), admin_order_path(order.id) %></td>
               <td><%= order.name %></td>
-              <td><%= order.order_products.count %></td>
+              <td>
+                <% @order_count = 0%>
+                <% order.order_products.each do |order_product| %>
+                <% @order_count += order_product.count %>
+                <% end %>
+                <%= @order_count %>
+              </td>
               <td>
                   <% if order.status == 1%>
                     <div class="badge badge-pill badge-danger">

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,5 +15,6 @@ module NaganoCake
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
+    config.time_zone = 'Tokyo'
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -27,7 +27,7 @@ ActiveRecord::Schema.define(version: 2020_08_19_062615) do
   create_table "cart_products", force: :cascade do |t|
     t.integer "product_id"
     t.integer "client_id"
-    t.integer "count", default: 1
+    t.integer "count"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end


### PR DESCRIPTION
以下の点を修正しました。確認お願いします。

全般
・注文日等の日時データのタイムゾーンをUTC(協定世界時)からJST(日本標準時)に変更

顧客
・ユーザーが配送先を登録していない状態で注文フォームのラジオボタン「登録住所」を選択した際のエラーを修正
・商品一覧画面の一覧商品およびジャンル一覧に無効ステータスを持った物まで表示されるバグを修正
・注文商品が税抜きで保存される点を修正
・URL直打ちによる無効なジャンル商品一覧および商品詳細への遷移を防止

管理者
・ログイン後遷移先を顧客側とは別に設定
・注文履歴一覧の注文個数のカウントを修正

