### PR TITLE
add_kana_validate

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -43,3 +43,35 @@ $(document).on('turbolinks:load', function () {
   });
 });
 
+
+
+
+
+$(function(){
+
+  function insertStr(input){
+    return input.slice(0, 3) + '-' + input.slice(3,input.length);
+  }
+
+  $("#client_postal_code").on('keyup',function(e){
+    var input = $(this).val();
+
+    var key = event.keyCode || event.charCode;
+    if( key == 8 || key == 46 ){
+      return false;
+    }
+
+    if(input.length === 3){
+      $(this).val(insertStr(input));
+    }
+  });
+
+  $("client_postal_code").on('blur',function(e){
+    var input = $(this).val();
+
+    if(input.length >= 3 && input.substr(3,1) !== '-'){
+      $(this).val(insertStr(input));
+    }
+  });
+}
+)

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -8,14 +8,14 @@ class Client < ApplicationRecord
   has_many :orders,             dependent: :destroy
   has_many :shipping_addresses, dependent: :destroy
 
-  validates :last_name,       presence: true
-  validates :first_name,      presence: true
-  validates :kana_last_name,  presence: true
-  validates :kana_first_name, presence: true
-  validates :email,           presence: true
-  validates :postal_code,     presence: true
-  validates :address,         presence: true
-  validates :phone_number,    presence: true
+  validates :last_name,        presence: true
+  validates :first_name,       presence: true
+  validates :kana_last_name,   presence: true, format: { with: /\A[\p{katakana}\p{blank}ー－]+\z/, message: 'はカタカナで入力して下さい。'}
+  validates :kana_first_name,  presence: true, format: { with: /\A[\p{katakana}\p{blank}ー－]+\z/, message: 'はカタカナで入力して下さい。'}
+  validates :email,            presence: true
+  validates :postal_code,      presence: true, length: { in: 7..8, message: "は７文字(ハイフンを除く)で入力してください。" }  
+  validates :address,          presence: true
+  validates :phone_number,     presence: true
 
   include JpPrefecture
   jp_prefecture :prefecture_code

--- a/app/views/clients/registrations/new.html.erb
+++ b/app/views/clients/registrations/new.html.erb
@@ -38,7 +38,7 @@
 
     <tr>
       <div class="field">
-        <th><%= f.label :郵便番号 %>(ハイフンなし)</th>
+        <th><%= f.label :郵便番号 %></th>
         <td></td>
         <td><%= f.text_field :postal_code, autofocus: true, autocomplete: "postal_code" %></td>
         <td></td>


### PR DESCRIPTION
・新規登録画面で名前（カナ）にカタカナ以外が入力されていた場合のバリデーションを追加
・郵便番号のハイフンを自動入力

確認お願いします。
